### PR TITLE
Add minimum (10 C) and maximum (30 C) temperatures for climate entity.

### DIFF
--- a/custom_components/local_daikin/climate.py
+++ b/custom_components/local_daikin/climate.py
@@ -156,6 +156,8 @@ class LocalDaikin(ClimateEntity):
         self._current_humidity = None
         self._runtime_today = None
         self._energy_today = None
+        self._max_temp = 30 # may need some logic to set this based on the device ID
+        self._min_temp = 10
 
         self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO, HVACMode.DRY, HVACMode.FAN_ONLY]
         self._attr_fan_modes = [
@@ -224,6 +226,18 @@ class LocalDaikin(ClimateEntity):
     def temperature_unit(self):
         """Return the unit of measurement."""
         return UnitOfTemperature.CELSIUS
+
+    # The max and min temps set the upper and lower bounds of the homeassistant climate control.
+    # When not set, API errors arise if you request temperatures that are out of bounds
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return self._max_temp
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return self._min_temp
 
     @property
     def target_temperature(self):


### PR DESCRIPTION
Hi again,

I noticed in testing that if I requested a temperature of 35 C through homeassistant, I would get an error from the API. My Daikin app allows temperatures between 10 and 30 C. I cannot see that these numbers are reported in the API calls we have so far, but cannot rule it out. It would probably be better for these values to not be hard-coded (if we could work out how to set them), but this PR will at least stop the APR errors.

It sets the homeassistant max_temp and min_temp properties.

Cheers
Martin