### PR TITLE
Handle negative temperatures

### DIFF
--- a/custom_components/local_daikin/climate.py
+++ b/custom_components/local_daikin/climate.py
@@ -364,7 +364,10 @@ class LocalDaikin(ClimateEntity):
 
     @staticmethod
     def hex_to_temp(value: str, divisor=2) -> float:
-        return int(value[:2], 16) / divisor
+        temp = int(value[:2], 16)
+        if temp >= 128:
+            temp -= 256
+        return temp / divisor
 
 
     def set_temperature(self, temperature: float, **kwargs):


### PR DESCRIPTION
The temperatures returned from the local API use Two's Complement to represent negative temperatures.
Handle these so the temperature shows e.g. `-1` instead of `127`

Closes https://github.com/Apoc182/local_daikin/issues/42