### PR TITLE
Add UI configuration and reconfiguration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Built quick and dirty as a bridge until we have a better solution available, thi
 
 4. Enter the IP address of your Daikin air conditioner.
 
+The integration also provides a page-based reconfiguration flow. Open the
+Local Daikin integration from **Settings → Devices & Services**, open the
+entry menu, and choose **Reconfigure** to update an adapter IP without editing
+Home Assistant storage files or removing the integration.
+
 ## Features
 
 - Full climate control (temperature, HVAC mode, fan, swing)

--- a/custom_components/local_daikin/__init__.py
+++ b/custom_components/local_daikin/__init__.py
@@ -1,10 +1,13 @@
 import asyncio
 
+from .const import DOMAIN
+
+
 async def async_setup(hass, config):
     return True
 
 async def async_setup_entry(hass, entry):
-    hass.data.setdefault("local_daikin", {})[entry.entry_id] = {
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
          "config": entry.data   
     }
     await hass.config_entries.async_forward_entry_setups(entry, ["climate", "switch", "sensor", "select"])
@@ -18,5 +21,5 @@ async def async_unload_entry(hass, entry):
         ])
     )
     if unload_ok:
-        hass.data["local_daikin"].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/custom_components/local_daikin/config_flow.py
+++ b/custom_components/local_daikin/config_flow.py
@@ -1,20 +1,103 @@
+"""Config flow for Local Daikin."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+
 from homeassistant import config_entries
 import voluptuous as vol
 
-DOMAIN = "local_daikin"
+from .const import CONF_IP_ADDRESS, DOMAIN
+
+
+def _normalise_ip(value: str) -> str:
+    """Return a canonical IP address or raise ValueError."""
+    return str(ipaddress.ip_address(value.strip()))
+
+
+def _schema(default: str | None = None) -> vol.Schema:
+    """Build the IP address form schema."""
+    field = vol.Required(CONF_IP_ADDRESS)
+    if default is not None:
+        field = vol.Required(CONF_IP_ADDRESS, default=default)
+    return vol.Schema({field: str})
+
 
 class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle adding and reconfiguring a Daikin LAN adapter."""
+
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        errors = {}
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Add a Daikin LAN adapter from the Home Assistant UI."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            ip = user_input["ip_address"]
-            await self.async_set_unique_id(ip)
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=f"Daikin {ip}", data={"ip_address": ip})
+            try:
+                ip = _normalise_ip(user_input[CONF_IP_ADDRESS])
+            except ValueError:
+                errors[CONF_IP_ADDRESS] = "invalid_ip"
+            else:
+                if self._is_ip_configured(ip):
+                    return self.async_abort(reason="already_configured")
+
+                # Keep the existing IP-based unique ID for compatibility with
+                # entries created by earlier releases of this integration.
+                await self.async_set_unique_id(ip)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=f"Daikin {ip}", data={CONF_IP_ADDRESS: ip}
+                )
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required("ip_address"): str}),
-            errors=errors
+            data_schema=_schema(),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Change the LAN adapter IP without removing the config entry."""
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+        current_ip = entry.data.get(CONF_IP_ADDRESS, "")
+
+        if user_input is not None:
+            try:
+                ip = _normalise_ip(user_input[CONF_IP_ADDRESS])
+            except ValueError:
+                errors[CONF_IP_ADDRESS] = "invalid_ip"
+            else:
+                if self._is_ip_configured(ip, exclude_entry_id=entry.entry_id):
+                    return self.async_abort(reason="already_configured")
+
+                # Older releases used the address as the config entry unique
+                # ID. It must move with the address when a user edits it.
+                self.hass.config_entries.async_update_entry(entry, unique_id=ip)
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_IP_ADDRESS: ip},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_schema(current_ip),
+            errors=errors,
+        )
+
+    def _is_ip_configured(
+        self, ip: str, exclude_entry_id: str | None = None
+    ) -> bool:
+        """Check both current data and legacy unique IDs for duplicates."""
+        return any(
+            entry.entry_id != exclude_entry_id
+            and (
+                entry.data.get(CONF_IP_ADDRESS) == ip
+                or entry.unique_id == ip
+            )
+            for entry in self.hass.config_entries.async_entries(DOMAIN)
         )

--- a/custom_components/local_daikin/const.py
+++ b/custom_components/local_daikin/const.py
@@ -1,0 +1,4 @@
+"""Constants for the Local Daikin integration."""
+
+DOMAIN = "local_daikin"
+CONF_IP_ADDRESS = "ip_address"

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/strings.json
+++ b/custom_components/local_daikin/strings.json
@@ -1,25 +1,24 @@
 {
+  "title": "Local Daikin",
   "config": {
     "step": {
       "user": {
         "title": "Add Daikin air conditioner",
         "description": "Enter the IP address of the Daikin LAN adapter.",
         "data": {
-          "ip_address": "IP Address"
+          "ip_address": "IP address"
         }
       },
       "reconfigure": {
         "title": "Reconfigure Daikin air conditioner",
         "description": "Update the IP address of the Daikin LAN adapter.",
         "data": {
-          "ip_address": "IP Address"
+          "ip_address": "IP address"
         }
       }
     },
     "error": {
-      "invalid_ip": "Enter a valid IPv4 or IPv6 address.",
-      "cannot_connect": "Cannot connect to the device.",
-      "unknown": "An unknown error occurred."
+      "invalid_ip": "Enter a valid IPv4 or IPv6 address."
     },
     "abort": {
       "already_configured": "This Daikin device is already configured.",

--- a/custom_components/local_daikin/translations/zh-Hant.json
+++ b/custom_components/local_daikin/translations/zh-Hant.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "新增大金冷氣",
+        "description": "輸入大金 LAN 轉接器的 IP 位址。",
+        "data": {
+          "ip_address": "IP 位址"
+        }
+      },
+      "reconfigure": {
+        "title": "重新設定大金冷氣",
+        "description": "更新大金 LAN 轉接器的 IP 位址。",
+        "data": {
+          "ip_address": "IP 位址"
+        }
+      }
+    },
+    "error": {
+      "invalid_ip": "請輸入有效的 IPv4 或 IPv6 位址。"
+    },
+    "abort": {
+      "already_configured": "這台大金冷氣已經設定過了。",
+      "reconfigure_successful": "大金冷氣設定已更新。"
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- Add a Home Assistant UI flow for adding a Daikin LAN adapter.
- Add a Reconfigure flow to update the adapter IP and reload the entry without editing storage.
- Validate IPv4/IPv6 input and prevent duplicate configured addresses.
- Add base, English, and Traditional Chinese translations.
- Bump the integration version to 1.1.0.

## Validation
- Python compileall passed.
- JSON validation passed.
- git diff --check passed.
- Full Home Assistant runtime tests were unavailable because Home Assistant is not installed in the local checkout.