### PR TITLE
Add configurable setup and automatic Daikin network discovery

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+      - run: python -m pip install -r requirements_test.txt
+      - run: >-
+          ruff check
+          custom_components/local_daikin/__init__.py
+          custom_components/local_daikin/config_flow.py
+          custom_components/local_daikin/const.py
+          custom_components/local_daikin/scanner.py
+          tests
+      - run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__
 cp_to_ha.sh
+.coverage
+.pytest_cache/
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ Home Assistant storage files or removing the integration.
 To discover multiple adapters at once, choose **Add Integration → Local
 Daikin → Scan the local network**. The scan defaults to the Home Assistant
 host's local `/24` network, verifies each candidate with the Daikin DSIOT API,
-and adds only devices that are not already configured. A custom IPv4 network
-such as `192.168.31.0/24` can be entered when the default network is not
-available.
+and adds only devices that are not already configured. The result reports
+partial failures instead of treating one successful device as a complete
+scan. A custom IPv4 network such as `192.168.31.0/24` can be entered when the
+default network is not available.
+
+Manual setup and reconfiguration also verify the DSIOT endpoint before saving.
+The integration uses the adapter MAC address as the stable config entry ID and
+gradually migrates older IP-based entries whenever the adapter is reachable.
+Only IPv4 is currently supported by the integration.
 
 The configuration pages are available in English and Traditional Chinese and
 follow the language selected for the Home Assistant user account. This covers

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Built quick and dirty as a bridge until we have a better solution available, thi
 
 4. Enter the IP address of your Daikin air conditioner.
 
+The integration also provides a page-based reconfiguration flow. Open the
+Local Daikin integration from **Settings → Devices & Services**, open the
+entry menu, and choose **Reconfigure** to update an adapter IP without editing
+Home Assistant storage files or removing the integration.
+
 ## Features
 
 - Full climate control (temperature, HVAC mode, fan, swing)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ and adds only devices that are not already configured. A custom IPv4 network
 such as `192.168.31.0/24` can be entered when the default network is not
 available.
 
+The configuration pages are available in English and Traditional Chinese and
+follow the language selected for the Home Assistant user account. This covers
+manual setup, reconfiguration, network scanning, validation errors, and scan
+results.
+
 ## Features
 
 - Full climate control (temperature, HVAC mode, fan, swing)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Local Daikin integration from **Settings → Devices & Services**, open the
 entry menu, and choose **Reconfigure** to update an adapter IP without editing
 Home Assistant storage files or removing the integration.
 
+To discover multiple adapters at once, choose **Add Integration → Local
+Daikin → Scan the local network**. The scan defaults to the Home Assistant
+host's local `/24` network, verifies each candidate with the Daikin DSIOT API,
+and adds only devices that are not already configured. A custom IPv4 network
+such as `192.168.31.0/24` can be entered when the default network is not
+available.
+
 ## Features
 
 - Full climate control (temperature, HVAC mode, fan, swing)

--- a/custom_components/local_daikin/__init__.py
+++ b/custom_components/local_daikin/__init__.py
@@ -1,16 +1,56 @@
 import asyncio
+import logging
 
 from .const import DOMAIN
+from .scanner import (
+    DaikinConnectionError,
+    async_get_device_info,
+    uses_legacy_unique_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_migrate_legacy_unique_id(hass, entry):
+    """Best-effort migration from a mutable IP identity to the adapter MAC."""
+    if not uses_legacy_unique_id(entry.unique_id):
+        return
+
+    ip = entry.data.get("ip_address")
+    if not ip:
+        return
+
+    try:
+        device = await async_get_device_info(hass, ip)
+    except DaikinConnectionError:
+        _LOGGER.debug("Deferring Local Daikin identity migration for %s", ip)
+        return
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("Unable to migrate Local Daikin identity for %s", ip)
+        return
+
+    existing = hass.config_entries.async_entry_for_domain_unique_id(
+        DOMAIN, device.mac
+    )
+    if existing is not None and existing.entry_id != entry.entry_id:
+        _LOGGER.error(
+            "Cannot migrate Local Daikin %s to MAC %s because it is already used",
+            ip,
+            device.mac,
+        )
+        return
+    hass.config_entries.async_update_entry(entry, unique_id=device.mac)
 
 
 async def async_setup(hass, config):
     return True
 
 async def async_setup_entry(hass, entry):
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-         "config": entry.data   
-    }
-    await hass.config_entries.async_forward_entry_setups(entry, ["climate", "switch", "sensor", "select"])
+    await _async_migrate_legacy_unique_id(hass, entry)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"config": entry.data}
+    await hass.config_entries.async_forward_entry_setups(
+        entry, ["climate", "switch", "sensor", "select"]
+    )
     return True
 
 async def async_unload_entry(hass, entry):

--- a/custom_components/local_daikin/__init__.py
+++ b/custom_components/local_daikin/__init__.py
@@ -1,10 +1,13 @@
 import asyncio
 
+from .const import DOMAIN
+
+
 async def async_setup(hass, config):
     return True
 
 async def async_setup_entry(hass, entry):
-    hass.data.setdefault("local_daikin", {})[entry.entry_id] = {
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
          "config": entry.data   
     }
     await hass.config_entries.async_forward_entry_setups(entry, ["climate", "switch", "sensor", "select"])
@@ -18,5 +21,5 @@ async def async_unload_entry(hass, entry):
         ])
     )
     if unload_ok:
-        hass.data["local_daikin"].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/custom_components/local_daikin/config_flow.py
+++ b/custom_components/local_daikin/config_flow.py
@@ -1,20 +1,103 @@
+"""Config flow for Local Daikin."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+
 from homeassistant import config_entries
 import voluptuous as vol
 
-DOMAIN = "local_daikin"
+from .const import CONF_IP_ADDRESS, DOMAIN
+
+
+def _normalise_ip(value: str) -> str:
+    """Return a canonical IP address or raise ValueError."""
+    return str(ipaddress.ip_address(value.strip()))
+
+
+def _schema(default: str | None = None) -> vol.Schema:
+    """Build the IP address form schema."""
+    field = vol.Required(CONF_IP_ADDRESS)
+    if default is not None:
+        field = vol.Required(CONF_IP_ADDRESS, default=default)
+    return vol.Schema({field: str})
+
 
 class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle adding and reconfiguring a Daikin LAN adapter."""
+
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        errors = {}
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Add a Daikin LAN adapter from the Home Assistant UI."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            ip = user_input["ip_address"]
-            await self.async_set_unique_id(ip)
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=f"Daikin {ip}", data={"ip_address": ip})
+            try:
+                ip = _normalise_ip(user_input[CONF_IP_ADDRESS])
+            except ValueError:
+                errors[CONF_IP_ADDRESS] = "invalid_ip"
+            else:
+                if self._is_ip_configured(ip):
+                    return self.async_abort(reason="already_configured")
+
+                # Keep the existing IP-based unique ID for compatibility with
+                # entries created by earlier releases of this integration.
+                await self.async_set_unique_id(ip)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=f"Daikin {ip}", data={CONF_IP_ADDRESS: ip}
+                )
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required("ip_address"): str}),
-            errors=errors
+            data_schema=_schema(),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Change the LAN adapter IP without removing the config entry."""
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+        current_ip = entry.data.get(CONF_IP_ADDRESS, "")
+
+        if user_input is not None:
+            try:
+                ip = _normalise_ip(user_input[CONF_IP_ADDRESS])
+            except ValueError:
+                errors[CONF_IP_ADDRESS] = "invalid_ip"
+            else:
+                if self._is_ip_configured(ip, exclude_entry_id=entry.entry_id):
+                    return self.async_abort(reason="already_configured")
+
+                # Older releases used the address as the config entry unique
+                # ID. It must move with the address when a user edits it.
+                self.hass.config_entries.async_update_entry(entry, unique_id=ip)
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_IP_ADDRESS: ip},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_schema(current_ip),
+            errors=errors,
+        )
+
+    def _is_ip_configured(
+        self, ip: str, exclude_entry_id: str | None = None
+    ) -> bool:
+        """Check both current data and legacy unique IDs for duplicates."""
+        return any(
+            entry.entry_id != exclude_entry_id
+            and (
+                entry.data.get(CONF_IP_ADDRESS) == ip
+                or entry.unique_id == ip
+            )
+            for entry in self.hass.config_entries.async_entries(DOMAIN)
         )

--- a/custom_components/local_daikin/config_flow.py
+++ b/custom_components/local_daikin/config_flow.py
@@ -92,13 +92,16 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     _LOGGER.exception("Unable to scan network %s", network)
                     errors["base"] = "scan_failed"
                 else:
+                    if not discovered:
+                        return self.async_abort(reason="no_devices_found")
+
                     new_ips = [
                         ip
                         for ip in discovered
                         if not self._is_ip_configured(ip)
                     ]
                     if not new_ips:
-                        return self.async_abort(reason="no_new_devices")
+                        return self.async_abort(reason="all_configured")
 
                     added = await self._async_add_entries(new_ips)
                     if added:

--- a/custom_components/local_daikin/config_flow.py
+++ b/custom_components/local_daikin/config_flow.py
@@ -4,22 +4,45 @@ from __future__ import annotations
 
 import ipaddress
 import logging
+from contextlib import suppress
+from dataclasses import dataclass
 from typing import Any
 
-from homeassistant import config_entries
-from homeassistant.config_entries import SOURCE_USER
 import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY
+from homeassistant.data_entry_flow import FlowResultType, UnknownFlow
 
 from .const import CONF_IP_ADDRESS, DOMAIN
-from .scanner import async_scan_network, get_default_network, parse_network
+from .scanner import (
+    DaikinConnectionError,
+    DaikinDeviceInfo,
+    async_get_device_info,
+    async_scan_network,
+    get_default_network,
+    parse_network,
+    uses_legacy_unique_id,
+)
 
 CONF_NETWORK = "network"
 _LOGGER = logging.getLogger(__name__)
 
 
 def _normalise_ip(value: str) -> str:
-    """Return a canonical IP address or raise ValueError."""
-    return str(ipaddress.ip_address(value.strip()))
+    """Return a canonical IPv4 address or raise ValueError."""
+    address = ipaddress.ip_address(value.strip())
+    if address.version != 4:
+        raise ValueError("Only IPv4 addresses are supported")
+    return str(address)
+
+
+@dataclass(frozen=True, slots=True)
+class AddEntriesResult:
+    """Results from adding all devices found by one network scan."""
+
+    added: tuple[str, ...]
+    skipped: tuple[str, ...]
+    failed: tuple[str, ...]
 
 
 def _schema(default: str | None = None) -> vol.Schema:
@@ -59,13 +82,13 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if self._is_ip_configured(ip):
                     return self.async_abort(reason="already_configured")
 
-                # Keep the existing IP-based unique ID for compatibility with
-                # entries created by earlier releases of this integration.
-                await self.async_set_unique_id(ip)
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=f"Daikin {ip}", data={CONF_IP_ADDRESS: ip}
-                )
+                device = await self._async_validate_device(ip, errors)
+                if device is not None:
+                    await self.async_set_unique_id(device.mac)
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(
+                        title=f"Daikin {ip}", data={CONF_IP_ADDRESS: ip}
+                    )
 
         return self.async_show_form(
             step_id="manual",
@@ -78,6 +101,7 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Scan the local network and add every new Daikin adapter."""
         errors: dict[str, str] = {}
+        description_placeholders: dict[str, str] | None = None
         default_network = get_default_network(self.hass) or ""
 
         if user_input is not None:
@@ -95,18 +119,37 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if not discovered:
                         return self.async_abort(reason="no_devices_found")
 
-                    new_ips = [
-                        ip
-                        for ip in discovered
-                        if not self._is_ip_configured(ip)
+                    new_devices = [
+                        device
+                        for device in discovered
+                        if not self._is_ip_configured(device.ip)
+                        and not self._is_unique_id_configured(device.mac)
                     ]
-                    if not new_ips:
+                    if not new_devices:
                         return self.async_abort(reason="all_configured")
 
-                    added = await self._async_add_entries(new_ips)
-                    if added:
-                        return self.async_abort(reason="scan_complete")
-                    errors["base"] = "scan_failed"
+                    result = await self._async_add_entries(new_devices)
+                    placeholders = {
+                        "added": str(len(result.added)),
+                        "skipped": str(len(result.skipped)),
+                        "failed": str(len(result.failed)),
+                        "failed_ips": ", ".join(result.failed) or "-",
+                    }
+                    if result.failed and result.added:
+                        return self.async_abort(
+                            reason="scan_partial",
+                            description_placeholders=placeholders,
+                        )
+                    if result.failed:
+                        errors["base"] = "scan_add_failed"
+                        description_placeholders = placeholders
+                    elif result.added:
+                        return self.async_abort(
+                            reason="scan_complete",
+                            description_placeholders=placeholders,
+                        )
+                    else:
+                        return self.async_abort(reason="all_configured")
 
         return self.async_show_form(
             step_id="scan",
@@ -114,34 +157,65 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {vol.Required(CONF_NETWORK, default=default_network): str}
             ),
             errors=errors,
+            description_placeholders=description_placeholders,
         )
 
-    async def _async_add_entries(self, ips: list[str]) -> bool:
+    async def async_step_integration_discovery(
+        self, discovery_info: dict[str, str]
+    ) -> config_entries.ConfigFlowResult:
+        """Add one adapter that was already verified by a network scan."""
+        ip = _normalise_ip(discovery_info[CONF_IP_ADDRESS])
+        mac = discovery_info["mac"]
+
+        if self._is_ip_configured(ip):
+            return self.async_abort(reason="already_configured")
+
+        await self.async_set_unique_id(mac)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=f"Daikin {ip}", data={CONF_IP_ADDRESS: ip}
+        )
+
+    async def _async_add_entries(
+        self, devices: list[DaikinDeviceInfo]
+    ) -> AddEntriesResult:
         """Run the normal manual config flow for each discovered IP."""
-        added = False
-        for ip in ips:
-            flow = await self.hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_USER},
-            )
-            flow_id = flow.get("flow_id")
-            if not flow_id:
-                continue
+        added: list[str] = []
+        skipped: list[str] = []
+        failed: list[str] = []
 
-            menu_result = await self.hass.config_entries.flow.async_configure(
-                flow_id,
-                {"next_step_id": "manual"},
-            )
-            if not menu_result.get("flow_id"):
-                continue
+        for device in devices:
+            result: config_entries.ConfigFlowResult | None = None
+            try:
+                result = await self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_INTEGRATION_DISCOVERY},
+                    data={CONF_IP_ADDRESS: device.ip, "mac": device.mac},
+                )
+                if result.get("type") == FlowResultType.CREATE_ENTRY:
+                    added.append(device.ip)
+                elif result.get("type") == FlowResultType.ABORT and result.get(
+                    "reason"
+                ) in {"already_configured", "already_in_progress"}:
+                    skipped.append(device.ip)
+                else:
+                    failed.append(device.ip)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception(
+                    "Unable to add discovered Daikin adapter %s", device.ip
+                )
+                failed.append(device.ip)
+            finally:
+                flow_id = result.get("flow_id") if result is not None else None
+                if flow_id is not None:
+                    with suppress(UnknownFlow):
+                        self.hass.config_entries.flow.async_abort(flow_id)
 
-            result = await self.hass.config_entries.flow.async_configure(
-                flow_id,
-                {CONF_IP_ADDRESS: ip},
-            )
-            if result.get("type") == "create_entry":
-                added = True
-        return added
+        return AddEntriesResult(
+            added=tuple(added),
+            skipped=tuple(skipped),
+            failed=tuple(failed),
+        )
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
@@ -160,13 +234,19 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if self._is_ip_configured(ip, exclude_entry_id=entry.entry_id):
                     return self.async_abort(reason="already_configured")
 
-                # Older releases used the address as the config entry unique
-                # ID. It must move with the address when a user edits it.
-                self.hass.config_entries.async_update_entry(entry, unique_id=ip)
-                return self.async_update_reload_and_abort(
-                    entry,
-                    data_updates={CONF_IP_ADDRESS: ip},
-                )
+                device = await self._async_validate_device(ip, errors)
+                if device is not None:
+                    await self.async_set_unique_id(device.mac)
+                    if uses_legacy_unique_id(entry.unique_id):
+                        self._abort_if_unique_id_configured()
+                    else:
+                        self._abort_if_unique_id_mismatch(reason="wrong_device")
+
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        unique_id=device.mac,
+                        data_updates={CONF_IP_ADDRESS: ip},
+                    )
 
         return self.async_show_form(
             step_id="reconfigure",
@@ -186,3 +266,25 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             for entry in self.hass.config_entries.async_entries(DOMAIN)
         )
+
+    def _is_unique_id_configured(
+        self, unique_id: str, exclude_entry_id: str | None = None
+    ) -> bool:
+        """Check whether a stable adapter identity already has an entry."""
+        entry = self.hass.config_entries.async_entry_for_domain_unique_id(
+            DOMAIN, unique_id
+        )
+        return entry is not None and entry.entry_id != exclude_entry_id
+
+    async def _async_validate_device(
+        self, ip: str, errors: dict[str, str]
+    ) -> DaikinDeviceInfo | None:
+        """Validate that an address is a reachable supported Daikin adapter."""
+        try:
+            return await async_get_device_info(self.hass, ip)
+        except DaikinConnectionError:
+            errors["base"] = "cannot_connect"
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Unexpected error validating Daikin adapter %s", ip)
+            errors["base"] = "unknown"
+        return None

--- a/custom_components/local_daikin/config_flow.py
+++ b/custom_components/local_daikin/config_flow.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import ipaddress
+import logging
 from typing import Any
 
 from homeassistant import config_entries
+from homeassistant.config_entries import SOURCE_USER
 import voluptuous as vol
 
 from .const import CONF_IP_ADDRESS, DOMAIN
+from .scanner import async_scan_network, get_default_network, parse_network
+
+CONF_NETWORK = "network"
+_LOGGER = logging.getLogger(__name__)
 
 
 def _normalise_ip(value: str) -> str:
@@ -32,7 +38,16 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
-        """Add a Daikin LAN adapter from the Home Assistant UI."""
+        """Choose manual setup or automatic local network discovery."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["manual", "scan"],
+        )
+
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Add a Daikin LAN adapter from a manually entered IP address."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -53,10 +68,77 @@ class DaikinConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="user",
+            step_id="manual",
             data_schema=_schema(),
             errors=errors,
         )
+
+    async def async_step_scan(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Scan the local network and add every new Daikin adapter."""
+        errors: dict[str, str] = {}
+        default_network = get_default_network(self.hass) or ""
+
+        if user_input is not None:
+            try:
+                network = parse_network(user_input[CONF_NETWORK])
+            except ValueError:
+                errors[CONF_NETWORK] = "invalid_network"
+            else:
+                try:
+                    discovered = await async_scan_network(self.hass, network)
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception("Unable to scan network %s", network)
+                    errors["base"] = "scan_failed"
+                else:
+                    new_ips = [
+                        ip
+                        for ip in discovered
+                        if not self._is_ip_configured(ip)
+                    ]
+                    if not new_ips:
+                        return self.async_abort(reason="no_new_devices")
+
+                    added = await self._async_add_entries(new_ips)
+                    if added:
+                        return self.async_abort(reason="scan_complete")
+                    errors["base"] = "scan_failed"
+
+        return self.async_show_form(
+            step_id="scan",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_NETWORK, default=default_network): str}
+            ),
+            errors=errors,
+        )
+
+    async def _async_add_entries(self, ips: list[str]) -> bool:
+        """Run the normal manual config flow for each discovered IP."""
+        added = False
+        for ip in ips:
+            flow = await self.hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            flow_id = flow.get("flow_id")
+            if not flow_id:
+                continue
+
+            menu_result = await self.hass.config_entries.flow.async_configure(
+                flow_id,
+                {"next_step_id": "manual"},
+            )
+            if not menu_result.get("flow_id"):
+                continue
+
+            result = await self.hass.config_entries.flow.async_configure(
+                flow_id,
+                {CONF_IP_ADDRESS: ip},
+            )
+            if result.get("type") == "create_entry":
+                added = True
+        return added
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/local_daikin/const.py
+++ b/custom_components/local_daikin/const.py
@@ -1,0 +1,4 @@
+"""Constants for the Local Daikin integration."""
+
+DOMAIN = "local_daikin"
+CONF_IP_ADDRESS = "ip_address"

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/manifest.json
+++ b/custom_components/local_daikin/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "local_daikin",
   "name": "Local Daikin",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "documentation": "https://github.com/Apoc182/local_daikin",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -83,15 +83,19 @@ def parse_network(value: str) -> ipaddress.IPv4Network:
 
 def _find_pn_value(nodes: object, *keys: str) -> object | None:
     """Find a value in Daikin's nested pn/pv/pch response structure."""
-    if not isinstance(nodes, list):
-        return None
-
     current_nodes = nodes
     for index, key in enumerate(keys):
+        if isinstance(current_nodes, dict):
+            candidates = [current_nodes]
+        elif isinstance(current_nodes, list):
+            candidates = current_nodes
+        else:
+            return None
+
         node = next(
             (
                 candidate
-                for candidate in current_nodes
+                for candidate in candidates
                 if isinstance(candidate, dict) and candidate.get("pn") == key
             ),
             None,
@@ -100,10 +104,7 @@ def _find_pn_value(nodes: object, *keys: str) -> object | None:
             return None
         if index == len(keys) - 1:
             return node.get("pv")
-        children = node.get("pch")
-        if not isinstance(children, list):
-            return None
-        current_nodes = children
+        current_nodes = node.get("pch")
     return None
 
 

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+import json
 import logging
 import re
 from collections.abc import Iterable
+from contextlib import suppress
 from dataclasses import dataclass
 
-import requests
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
-from requests.exceptions import RequestException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,8 @@ MAX_SCAN_ADDRESSES = 1024
 SCAN_CONCURRENCY = 8
 # Some Daikin adapters need more than a second to answer after an ARP lookup.
 # Keep enough parallelism for a /24 scan while allowing slow LAN adapters through.
-REQUEST_TIMEOUT = (2.0, 2.0)
+CONNECT_TIMEOUT = 2.0
+READ_TIMEOUT = 2.0
 
 
 class DaikinConnectionError(Exception):
@@ -134,32 +135,71 @@ def _parse_device_info(ip: str, data: object) -> DaikinDeviceInfo:
     return DaikinDeviceInfo(ip=ip, mac=mac)
 
 
-def _fetch_device_info(ip: str) -> DaikinDeviceInfo:
-    """Fetch a Daikin identity with the transport used by its control API."""
+async def _async_request_device_info(ip: str) -> object:
+    """Send a bounded HTTP request compatible with Daikin's minimal server."""
+    writer: asyncio.StreamWriter | None = None
     try:
-        response = requests.post(
-            f"http://{ip}{DISCOVERY_PATH}",
-            json=DISCOVERY_PAYLOAD,
-            timeout=REQUEST_TIMEOUT,
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(ip, 80), timeout=CONNECT_TIMEOUT
         )
-        if response.status_code != 200:
+        body = json.dumps(DISCOVERY_PAYLOAD, separators=(",", ":")).encode()
+        request = (
+            f"POST {DISCOVERY_PATH} HTTP/1.1\r\n"
+            f"Host: {ip}\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode() + body
+        writer.write(request)
+        await asyncio.wait_for(writer.drain(), timeout=READ_TIMEOUT)
+
+        header_data = await asyncio.wait_for(
+            reader.readuntil(b"\r\n\r\n"), timeout=READ_TIMEOUT
+        )
+        header_lines = header_data.decode("iso-8859-1").split("\r\n")
+        status_parts = header_lines[0].split(" ", 2)
+        if len(status_parts) < 2 or status_parts[1] != "200":
+            status = status_parts[1] if len(status_parts) >= 2 else "invalid"
             raise DaikinConnectionError(
-                f"The device returned HTTP status {response.status_code}"
+                f"The device returned HTTP status {status}"
             )
-        data = response.json()
+
+        headers = {
+            name.strip().lower(): value.strip()
+            for line in header_lines[1:]
+            if ":" in line
+            for name, value in [line.split(":", 1)]
+        }
+        content_length = int(headers.get("content-length", "0"))
+        if content_length <= 0:
+            raise DaikinConnectionError("The device returned an empty response")
+        response_body = await asyncio.wait_for(
+            reader.readexactly(content_length), timeout=READ_TIMEOUT
+        )
+        return json.loads(response_body)
     except DaikinConnectionError:
         raise
-    except (RequestException, OSError, ValueError) as err:
+    except (
+        TimeoutError,
+        OSError,
+        ValueError,
+        asyncio.IncompleteReadError,
+        asyncio.LimitOverrunError,
+    ) as err:
         raise DaikinConnectionError("Unable to connect to the Daikin adapter") from err
-
-    return _parse_device_info(ip, data)
+    finally:
+        if writer is not None:
+            writer.close()
+            with suppress(Exception):
+                await writer.wait_closed()
 
 
 async def _async_fetch_device_info(
     hass: HomeAssistant, ip: str
 ) -> DaikinDeviceInfo:
-    """Fetch one adapter without blocking Home Assistant's event loop."""
-    return await hass.async_add_executor_job(_fetch_device_info, ip)
+    """Fetch and parse one adapter identity."""
+    del hass
+    return _parse_device_info(ip, await _async_request_device_info(ip))
 
 
 async def async_get_device_info(

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -22,8 +22,10 @@ DISCOVERY_PAYLOAD = {
 }
 DEFAULT_PREFIX = 24
 MAX_SCAN_ADDRESSES = 1024
-SCAN_CONCURRENCY = 32
-REQUEST_TIMEOUT = ClientTimeout(total=1.5, connect=0.4, sock_read=0.8)
+SCAN_CONCURRENCY = 64
+# Some Daikin adapters need more than a second to answer after an ARP lookup.
+# Keep enough parallelism for a /24 scan while allowing slow LAN adapters through.
+REQUEST_TIMEOUT = ClientTimeout(total=4.0, connect=2.0, sock_read=2.0)
 
 
 class DaikinConnectionError(Exception):

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -22,7 +22,7 @@ DISCOVERY_PAYLOAD = {
 }
 DEFAULT_PREFIX = 24
 MAX_SCAN_ADDRESSES = 1024
-SCAN_CONCURRENCY = 64
+SCAN_CONCURRENCY = 8
 # Some Daikin adapters need more than a second to answer after an ARP lookup.
 # Keep enough parallelism for a /24 scan while allowing slow LAN adapters through.
 REQUEST_TIMEOUT = ClientTimeout(total=4.0, connect=2.0, sock_read=2.0)
@@ -170,7 +170,8 @@ async def _probe_ip(
     async with semaphore:
         try:
             return await _async_fetch_device_info(session, ip)
-        except DaikinConnectionError:
+        except DaikinConnectionError as err:
+            _LOGGER.debug("Daikin discovery probe failed for %s: %s", ip, err)
             return None
 
 

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -27,6 +27,7 @@ SCAN_CONCURRENCY = 8
 # Keep enough parallelism for a /24 scan while allowing slow LAN adapters through.
 CONNECT_TIMEOUT = 2.0
 READ_TIMEOUT = 2.0
+CLOSE_TIMEOUT = 0.5
 
 
 class DaikinConnectionError(Exception):
@@ -191,7 +192,9 @@ async def _async_request_device_info(ip: str) -> object:
         if writer is not None:
             writer.close()
             with suppress(Exception):
-                await writer.wait_closed()
+                await asyncio.wait_for(
+                    writer.wait_closed(), timeout=CLOSE_TIMEOUT
+                )
 
 
 async def _async_fetch_device_info(

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -9,10 +9,10 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from aiohttp import ClientError, ClientTimeout
+import requests
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from requests.exceptions import RequestException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ MAX_SCAN_ADDRESSES = 1024
 SCAN_CONCURRENCY = 8
 # Some Daikin adapters need more than a second to answer after an ARP lookup.
 # Keep enough parallelism for a /24 scan while allowing slow LAN adapters through.
-REQUEST_TIMEOUT = ClientTimeout(total=4.0, connect=2.0, sock_read=2.0)
+REQUEST_TIMEOUT = (2.0, 2.0)
 
 
 class DaikinConnectionError(Exception):
@@ -134,42 +134,48 @@ def _parse_device_info(ip: str, data: object) -> DaikinDeviceInfo:
     return DaikinDeviceInfo(ip=ip, mac=mac)
 
 
-async def _async_fetch_device_info(session, ip: str) -> DaikinDeviceInfo:
-    """Fetch a Daikin adapter identity with an existing HTTP session."""
+def _fetch_device_info(ip: str) -> DaikinDeviceInfo:
+    """Fetch a Daikin identity with the transport used by its control API."""
     try:
-        async with session.post(
+        response = requests.post(
             f"http://{ip}{DISCOVERY_PATH}",
             json=DISCOVERY_PAYLOAD,
             timeout=REQUEST_TIMEOUT,
-        ) as response:
-            if response.status != 200:
-                raise DaikinConnectionError(
-                    f"The device returned HTTP status {response.status}"
-                )
-            data = await response.json(content_type=None)
+        )
+        if response.status_code != 200:
+            raise DaikinConnectionError(
+                f"The device returned HTTP status {response.status_code}"
+            )
+        data = response.json()
     except DaikinConnectionError:
         raise
-    except (TimeoutError, ClientError, OSError, ValueError) as err:
+    except (RequestException, OSError, ValueError) as err:
         raise DaikinConnectionError("Unable to connect to the Daikin adapter") from err
 
     return _parse_device_info(ip, data)
+
+
+async def _async_fetch_device_info(
+    hass: HomeAssistant, ip: str
+) -> DaikinDeviceInfo:
+    """Fetch one adapter without blocking Home Assistant's event loop."""
+    return await hass.async_add_executor_job(_fetch_device_info, ip)
 
 
 async def async_get_device_info(
     hass: HomeAssistant, ip: str
 ) -> DaikinDeviceInfo:
     """Validate one address and return its stable adapter identity."""
-    session = async_get_clientsession(hass)
-    return await _async_fetch_device_info(session, ip)
+    return await _async_fetch_device_info(hass, ip)
 
 
 async def _probe_ip(
-    session, ip: str, semaphore: asyncio.Semaphore
+    hass: HomeAssistant, ip: str, semaphore: asyncio.Semaphore
 ) -> DaikinDeviceInfo | None:
     """Probe one address and return its identity when it is a Daikin adapter."""
     async with semaphore:
         try:
-            return await _async_fetch_device_info(session, ip)
+            return await _async_fetch_device_info(hass, ip)
         except DaikinConnectionError as err:
             _LOGGER.debug("Daikin discovery probe failed for %s: %s", ip, err)
             return None
@@ -179,11 +185,10 @@ async def async_scan_network(
     hass: HomeAssistant, network: ipaddress.IPv4Network
 ) -> list[DaikinDeviceInfo]:
     """Scan an IPv4 network for Daikin LAN adapters."""
-    session = async_get_clientsession(hass)
     semaphore = asyncio.Semaphore(SCAN_CONCURRENCY)
     addresses: Iterable[ipaddress.IPv4Address] = network.hosts()
     results = await asyncio.gather(
-        *(_probe_ip(session, str(ip), semaphore) for ip in addresses)
+        *(_probe_ip(hass, str(ip), semaphore) for ip in addresses)
     )
     found = sorted(
         (device for device in results if device is not None),

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -28,6 +28,7 @@ SCAN_CONCURRENCY = 8
 CONNECT_TIMEOUT = 2.0
 READ_TIMEOUT = 2.0
 CLOSE_TIMEOUT = 0.5
+PROBE_TIMEOUT = 6.0
 
 
 class DaikinConnectionError(Exception):
@@ -140,9 +141,11 @@ async def _async_request_device_info(ip: str) -> object:
     """Send a bounded HTTP request compatible with Daikin's minimal server."""
     writer: asyncio.StreamWriter | None = None
     try:
+        _LOGGER.debug("Opening Daikin discovery connection to %s", ip)
         reader, writer = await asyncio.wait_for(
             asyncio.open_connection(ip, 80), timeout=CONNECT_TIMEOUT
         )
+        _LOGGER.debug("Connected to Daikin discovery address %s", ip)
         body = json.dumps(DISCOVERY_PAYLOAD, separators=(",", ":")).encode()
         request = (
             f"POST {DISCOVERY_PATH} HTTP/1.1\r\n"
@@ -157,6 +160,7 @@ async def _async_request_device_info(ip: str) -> object:
         header_data = await asyncio.wait_for(
             reader.readuntil(b"\r\n\r\n"), timeout=READ_TIMEOUT
         )
+        _LOGGER.debug("Received Daikin discovery headers from %s", ip)
         header_lines = header_data.decode("iso-8859-1").split("\r\n")
         status_parts = header_lines[0].split(" ", 2)
         if len(status_parts) < 2 or status_parts[1] != "200":
@@ -177,6 +181,7 @@ async def _async_request_device_info(ip: str) -> object:
         response_body = await asyncio.wait_for(
             reader.readexactly(content_length), timeout=READ_TIMEOUT
         )
+        _LOGGER.debug("Received Daikin discovery body from %s", ip)
         return json.loads(response_body)
     except DaikinConnectionError:
         raise
@@ -202,7 +207,14 @@ async def _async_fetch_device_info(
 ) -> DaikinDeviceInfo:
     """Fetch and parse one adapter identity."""
     del hass
-    return _parse_device_info(ip, await _async_request_device_info(ip))
+    try:
+        async with asyncio.timeout(PROBE_TIMEOUT):
+            data = await _async_request_device_info(ip)
+    except TimeoutError as err:
+        raise DaikinConnectionError(
+            "Timed out while connecting to the Daikin adapter"
+        ) from err
+    return _parse_device_info(ip, data)
 
 
 async def async_get_device_info(

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -1,0 +1,99 @@
+"""Discover Daikin LAN adapters on the local IPv4 network."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+from collections.abc import Iterable
+
+from aiohttp import ClientError, ClientTimeout
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+_LOGGER = logging.getLogger(__name__)
+
+DISCOVERY_PATH = "/dsiot/multireq"
+DISCOVERY_PAYLOAD = {
+    "requests": [{"op": 2, "to": "/dsiot/edge.adp_i"}],
+}
+DEFAULT_PREFIX = 24
+MAX_SCAN_ADDRESSES = 1024
+SCAN_CONCURRENCY = 32
+REQUEST_TIMEOUT = ClientTimeout(total=1.5, connect=0.4, sock_read=0.8)
+
+
+def get_default_network(hass: HomeAssistant) -> str | None:
+    """Return the HA host's local /24 network when it is available."""
+    local_ip = getattr(getattr(hass.config, "api", None), "local_ip", None)
+    if not local_ip:
+        return None
+
+    try:
+        address = ipaddress.ip_address(str(local_ip))
+    except ValueError:
+        return None
+
+    if address.version != 4:
+        return None
+
+    return str(ipaddress.ip_network(f"{address}/{DEFAULT_PREFIX}", strict=False))
+
+
+def parse_network(value: str) -> ipaddress.IPv4Network:
+    """Validate a user-provided IPv4 network for scanning."""
+    network = ipaddress.ip_network(value.strip(), strict=False)
+    if network.version != 4:
+        raise ValueError("Only IPv4 networks are supported")
+    if network.num_addresses > MAX_SCAN_ADDRESSES:
+        raise ValueError("The network is too large to scan")
+    return network
+
+
+def _has_daikin_response(data: object) -> bool:
+    """Check for the Daikin adapter response marker."""
+    if not isinstance(data, dict):
+        return False
+    responses = data.get("responses")
+    if not isinstance(responses, list):
+        return False
+    return any(
+        isinstance(response, dict)
+        and response.get("fr") == "/dsiot/edge.adp_i"
+        for response in responses
+    )
+
+
+async def _probe_ip(
+    session, ip: str, semaphore: asyncio.Semaphore
+) -> str | None:
+    """Probe one address and return it only when it is a Daikin adapter."""
+    async with semaphore:
+        try:
+            async with session.post(
+                f"http://{ip}{DISCOVERY_PATH}",
+                json=DISCOVERY_PAYLOAD,
+                timeout=REQUEST_TIMEOUT,
+            ) as response:
+                if response.status != 200:
+                    return None
+                data = await response.json(content_type=None)
+        except (asyncio.TimeoutError, ClientError, OSError, ValueError):
+            return None
+
+    return ip if _has_daikin_response(data) else None
+
+
+async def async_scan_network(
+    hass: HomeAssistant, network: ipaddress.IPv4Network
+) -> list[str]:
+    """Scan an IPv4 network for Daikin LAN adapters."""
+    session = async_get_clientsession(hass)
+    semaphore = asyncio.Semaphore(SCAN_CONCURRENCY)
+    addresses: Iterable[ipaddress.IPv4Address] = network.hosts()
+    results = await asyncio.gather(
+        *(_probe_ip(session, str(ip), semaphore) for ip in addresses)
+    )
+    found = sorted(ip for ip in results if ip is not None)
+    _LOGGER.info("Local Daikin scan found %d adapter(s): %s", len(found), found)
+    return found

--- a/custom_components/local_daikin/scanner.py
+++ b/custom_components/local_daikin/scanner.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import re
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from aiohttp import ClientError, ClientTimeout
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,6 +24,29 @@ DEFAULT_PREFIX = 24
 MAX_SCAN_ADDRESSES = 1024
 SCAN_CONCURRENCY = 32
 REQUEST_TIMEOUT = ClientTimeout(total=1.5, connect=0.4, sock_read=0.8)
+
+
+class DaikinConnectionError(Exception):
+    """Raised when an address does not expose a supported Daikin adapter."""
+
+
+@dataclass(frozen=True, slots=True)
+class DaikinDeviceInfo:
+    """Identity returned by a Daikin LAN adapter."""
+
+    ip: str
+    mac: str
+
+
+def uses_legacy_unique_id(unique_id: str | None) -> bool:
+    """Return whether a config entry still uses an IP address as identity."""
+    if unique_id is None:
+        return True
+    try:
+        ipaddress.ip_address(unique_id)
+    except ValueError:
+        return False
+    return True
 
 
 def get_default_network(hass: HomeAssistant) -> str | None:
@@ -50,43 +76,105 @@ def parse_network(value: str) -> ipaddress.IPv4Network:
     return network
 
 
-def _has_daikin_response(data: object) -> bool:
-    """Check for the Daikin adapter response marker."""
+def _find_pn_value(nodes: object, *keys: str) -> object | None:
+    """Find a value in Daikin's nested pn/pv/pch response structure."""
+    if not isinstance(nodes, list):
+        return None
+
+    current_nodes = nodes
+    for index, key in enumerate(keys):
+        node = next(
+            (
+                candidate
+                for candidate in current_nodes
+                if isinstance(candidate, dict) and candidate.get("pn") == key
+            ),
+            None,
+        )
+        if node is None:
+            return None
+        if index == len(keys) - 1:
+            return node.get("pv")
+        children = node.get("pch")
+        if not isinstance(children, list):
+            return None
+        current_nodes = children
+    return None
+
+
+def _parse_device_info(ip: str, data: object) -> DaikinDeviceInfo:
+    """Extract and normalize a Daikin adapter identity."""
     if not isinstance(data, dict):
-        return False
+        raise DaikinConnectionError("The device returned an invalid response")
     responses = data.get("responses")
     if not isinstance(responses, list):
-        return False
-    return any(
-        isinstance(response, dict)
-        and response.get("fr") == "/dsiot/edge.adp_i"
-        for response in responses
+        raise DaikinConnectionError("The device response has no responses list")
+
+    adapter_response = next(
+        (
+            response
+            for response in responses
+            if isinstance(response, dict)
+            and response.get("fr") == "/dsiot/edge.adp_i"
+        ),
+        None,
     )
+    if adapter_response is None:
+        raise DaikinConnectionError("The address is not a supported Daikin adapter")
+
+    raw_mac = _find_pn_value(adapter_response.get("pc"), "adp_i", "mac")
+    if not isinstance(raw_mac, str) or not raw_mac.strip():
+        raise DaikinConnectionError("The Daikin adapter did not return a MAC address")
+
+    mac = format_mac(raw_mac)
+    if re.fullmatch(r"[0-9a-f]{2}(?::[0-9a-f]{2}){5}", mac) is None:
+        raise DaikinConnectionError("The Daikin adapter returned an invalid MAC")
+    return DaikinDeviceInfo(ip=ip, mac=mac)
+
+
+async def _async_fetch_device_info(session, ip: str) -> DaikinDeviceInfo:
+    """Fetch a Daikin adapter identity with an existing HTTP session."""
+    try:
+        async with session.post(
+            f"http://{ip}{DISCOVERY_PATH}",
+            json=DISCOVERY_PAYLOAD,
+            timeout=REQUEST_TIMEOUT,
+        ) as response:
+            if response.status != 200:
+                raise DaikinConnectionError(
+                    f"The device returned HTTP status {response.status}"
+                )
+            data = await response.json(content_type=None)
+    except DaikinConnectionError:
+        raise
+    except (TimeoutError, ClientError, OSError, ValueError) as err:
+        raise DaikinConnectionError("Unable to connect to the Daikin adapter") from err
+
+    return _parse_device_info(ip, data)
+
+
+async def async_get_device_info(
+    hass: HomeAssistant, ip: str
+) -> DaikinDeviceInfo:
+    """Validate one address and return its stable adapter identity."""
+    session = async_get_clientsession(hass)
+    return await _async_fetch_device_info(session, ip)
 
 
 async def _probe_ip(
     session, ip: str, semaphore: asyncio.Semaphore
-) -> str | None:
-    """Probe one address and return it only when it is a Daikin adapter."""
+) -> DaikinDeviceInfo | None:
+    """Probe one address and return its identity when it is a Daikin adapter."""
     async with semaphore:
         try:
-            async with session.post(
-                f"http://{ip}{DISCOVERY_PATH}",
-                json=DISCOVERY_PAYLOAD,
-                timeout=REQUEST_TIMEOUT,
-            ) as response:
-                if response.status != 200:
-                    return None
-                data = await response.json(content_type=None)
-        except (asyncio.TimeoutError, ClientError, OSError, ValueError):
+            return await _async_fetch_device_info(session, ip)
+        except DaikinConnectionError:
             return None
-
-    return ip if _has_daikin_response(data) else None
 
 
 async def async_scan_network(
     hass: HomeAssistant, network: ipaddress.IPv4Network
-) -> list[str]:
+) -> list[DaikinDeviceInfo]:
     """Scan an IPv4 network for Daikin LAN adapters."""
     session = async_get_clientsession(hass)
     semaphore = asyncio.Semaphore(SCAN_CONCURRENCY)
@@ -94,6 +182,13 @@ async def async_scan_network(
     results = await asyncio.gather(
         *(_probe_ip(session, str(ip), semaphore) for ip in addresses)
     )
-    found = sorted(ip for ip in results if ip is not None)
-    _LOGGER.info("Local Daikin scan found %d adapter(s): %s", len(found), found)
+    found = sorted(
+        (device for device in results if device is not None),
+        key=lambda device: ipaddress.ip_address(device.ip),
+    )
+    _LOGGER.info(
+        "Local Daikin scan found %d adapter(s): %s",
+        len(found),
+        [device.ip for device in found],
+    )
     return found

--- a/custom_components/local_daikin/strings.json
+++ b/custom_components/local_daikin/strings.json
@@ -40,7 +40,8 @@
     "abort": {
       "already_configured": "This Daikin device is already configured.",
       "reconfigure_successful": "Daikin configuration updated.",
-      "no_new_devices": "No new Daikin devices were found.",
+      "no_devices_found": "No Daikin devices were found on the selected network.",
+      "all_configured": "All discovered Daikin devices are already configured.",
       "scan_complete": "The discovered Daikin devices were added."
     }
   }

--- a/custom_components/local_daikin/strings.json
+++ b/custom_components/local_daikin/strings.json
@@ -35,7 +35,9 @@
     "error": {
       "invalid_ip": "Enter a valid IPv4 or IPv6 address.",
       "invalid_network": "Enter a valid IPv4 network, such as 192.168.1.0/24.",
-      "scan_failed": "The network scan could not be completed."
+      "scan_failed": "The network scan could not be completed.",
+      "cannot_connect": "Cannot connect to the device.",
+      "unknown": "An unknown error occurred."
     },
     "abort": {
       "already_configured": "This Daikin device is already configured.",

--- a/custom_components/local_daikin/strings.json
+++ b/custom_components/local_daikin/strings.json
@@ -1,7 +1,7 @@
 {
   "title": "Local Daikin",
   "config": {
-    "menu": {
+    "step": {
       "user": {
         "title": "Configure Local Daikin",
         "description": "Choose how to add your Daikin air conditioners.",
@@ -9,10 +9,8 @@
           "manual": "Enter an IP address",
           "scan": "Scan the local network"
         }
-      }
-    },
-    "step": {
-      "user": {
+      },
+      "manual": {
         "title": "Add Daikin air conditioner",
         "description": "Enter the IP address of the Daikin LAN adapter.",
         "data": {

--- a/custom_components/local_daikin/strings.json
+++ b/custom_components/local_daikin/strings.json
@@ -1,6 +1,16 @@
 {
   "title": "Local Daikin",
   "config": {
+    "menu": {
+      "user": {
+        "title": "Configure Local Daikin",
+        "description": "Choose how to add your Daikin air conditioners.",
+        "menu_options": {
+          "manual": "Enter an IP address",
+          "scan": "Scan the local network"
+        }
+      }
+    },
     "step": {
       "user": {
         "title": "Add Daikin air conditioner",
@@ -15,14 +25,25 @@
         "data": {
           "ip_address": "IP address"
         }
+      },
+      "scan": {
+        "title": "Scan local network",
+        "description": "Scan the selected IPv4 network for Daikin LAN adapters and add new devices.",
+        "data": {
+          "network": "IPv4 network"
+        }
       }
     },
     "error": {
-      "invalid_ip": "Enter a valid IPv4 or IPv6 address."
+      "invalid_ip": "Enter a valid IPv4 or IPv6 address.",
+      "invalid_network": "Enter a valid IPv4 network, such as 192.168.1.0/24.",
+      "scan_failed": "The network scan could not be completed."
     },
     "abort": {
       "already_configured": "This Daikin device is already configured.",
-      "reconfigure_successful": "Daikin configuration updated."
+      "reconfigure_successful": "Daikin configuration updated.",
+      "no_new_devices": "No new Daikin devices were found.",
+      "scan_complete": "The discovered Daikin devices were added."
     }
   }
 }

--- a/custom_components/local_daikin/strings.json
+++ b/custom_components/local_daikin/strings.json
@@ -1,25 +1,24 @@
 {
+  "title": "Local Daikin",
   "config": {
     "step": {
       "user": {
         "title": "Add Daikin air conditioner",
         "description": "Enter the IP address of the Daikin LAN adapter.",
         "data": {
-          "ip_address": "IP Address"
+          "ip_address": "IP address"
         }
       },
       "reconfigure": {
         "title": "Reconfigure Daikin air conditioner",
         "description": "Update the IP address of the Daikin LAN adapter.",
         "data": {
-          "ip_address": "IP Address"
+          "ip_address": "IP address"
         }
       }
     },
     "error": {
-      "invalid_ip": "Enter a valid IPv4 or IPv6 address.",
-      "cannot_connect": "Cannot connect to the device.",
-      "unknown": "An unknown error occurred."
+      "invalid_ip": "Enter a valid IPv4 or IPv6 address."
     },
     "abort": {
       "already_configured": "This Daikin device is already configured.",

--- a/custom_components/local_daikin/strings.json
+++ b/custom_components/local_daikin/strings.json
@@ -33,18 +33,21 @@
       }
     },
     "error": {
-      "invalid_ip": "Enter a valid IPv4 or IPv6 address.",
+      "invalid_ip": "Enter a valid IPv4 address.",
       "invalid_network": "Enter a valid IPv4 network, such as 192.168.1.0/24.",
       "scan_failed": "The network scan could not be completed.",
+      "scan_add_failed": "No Daikin devices could be added. Failed addresses: {failed_ips}.",
       "cannot_connect": "Cannot connect to the device.",
       "unknown": "An unknown error occurred."
     },
     "abort": {
       "already_configured": "This Daikin device is already configured.",
+      "wrong_device": "The new address belongs to a different Daikin device.",
       "reconfigure_successful": "Daikin configuration updated.",
       "no_devices_found": "No Daikin devices were found on the selected network.",
       "all_configured": "All discovered Daikin devices are already configured.",
-      "scan_complete": "The discovered Daikin devices were added."
+      "scan_complete": "Added {added} Daikin device(s); {skipped} were already configured.",
+      "scan_partial": "Added {added} Daikin device(s), skipped {skipped}, and failed to add {failed}: {failed_ips}."
     }
   }
 }

--- a/custom_components/local_daikin/translations/en.json
+++ b/custom_components/local_daikin/translations/en.json
@@ -41,7 +41,8 @@
     "abort": {
       "already_configured": "This Daikin device is already configured.",
       "reconfigure_successful": "Daikin configuration updated.",
-      "no_new_devices": "No new Daikin devices were found.",
+      "no_devices_found": "No Daikin devices were found on the selected network.",
+      "all_configured": "All discovered Daikin devices are already configured.",
       "scan_complete": "The discovered Daikin devices were added."
     }
   }

--- a/custom_components/local_daikin/translations/en.json
+++ b/custom_components/local_daikin/translations/en.json
@@ -1,5 +1,15 @@
 {
   "config": {
+    "menu": {
+      "user": {
+        "title": "Configure Local Daikin",
+        "description": "Choose how to add your Daikin air conditioners.",
+        "menu_options": {
+          "manual": "Enter an IP address",
+          "scan": "Scan the local network"
+        }
+      }
+    },
     "step": {
       "user": {
         "title": "Add Daikin air conditioner",
@@ -14,16 +24,27 @@
         "data": {
           "ip_address": "IP Address"
         }
+      },
+      "scan": {
+        "title": "Scan local network",
+        "description": "Scan the selected IPv4 network for Daikin LAN adapters and add new devices.",
+        "data": {
+          "network": "IPv4 network"
+        }
       }
     },
     "error": {
       "invalid_ip": "Enter a valid IPv4 or IPv6 address.",
+      "invalid_network": "Enter a valid IPv4 network, such as 192.168.1.0/24.",
+      "scan_failed": "The network scan could not be completed.",
       "cannot_connect": "Cannot connect to the device.",
       "unknown": "An unknown error occurred."
     },
     "abort": {
       "already_configured": "This Daikin device is already configured.",
-      "reconfigure_successful": "Daikin configuration updated."
+      "reconfigure_successful": "Daikin configuration updated.",
+      "no_new_devices": "No new Daikin devices were found.",
+      "scan_complete": "The discovered Daikin devices were added."
     }
   }
 }

--- a/custom_components/local_daikin/translations/en.json
+++ b/custom_components/local_daikin/translations/en.json
@@ -32,18 +32,21 @@
       }
     },
     "error": {
-      "invalid_ip": "Enter a valid IPv4 or IPv6 address.",
+      "invalid_ip": "Enter a valid IPv4 address.",
       "invalid_network": "Enter a valid IPv4 network, such as 192.168.1.0/24.",
       "scan_failed": "The network scan could not be completed.",
+      "scan_add_failed": "No Daikin devices could be added. Failed addresses: {failed_ips}.",
       "cannot_connect": "Cannot connect to the device.",
       "unknown": "An unknown error occurred."
     },
     "abort": {
       "already_configured": "This Daikin device is already configured.",
+      "wrong_device": "The new address belongs to a different Daikin device.",
       "reconfigure_successful": "Daikin configuration updated.",
       "no_devices_found": "No Daikin devices were found on the selected network.",
       "all_configured": "All discovered Daikin devices are already configured.",
-      "scan_complete": "The discovered Daikin devices were added."
+      "scan_complete": "Added {added} Daikin device(s); {skipped} were already configured.",
+      "scan_partial": "Added {added} Daikin device(s), skipped {skipped}, and failed to add {failed}: {failed_ips}."
     }
   }
 }

--- a/custom_components/local_daikin/translations/en.json
+++ b/custom_components/local_daikin/translations/en.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "menu": {
+    "step": {
       "user": {
         "title": "Configure Local Daikin",
         "description": "Choose how to add your Daikin air conditioners.",
@@ -8,10 +8,8 @@
           "manual": "Enter an IP address",
           "scan": "Scan the local network"
         }
-      }
-    },
-    "step": {
-      "user": {
+      },
+      "manual": {
         "title": "Add Daikin air conditioner",
         "description": "Enter the IP address of the Daikin LAN adapter.",
         "data": {

--- a/custom_components/local_daikin/translations/zh-Hant.json
+++ b/custom_components/local_daikin/translations/zh-Hant.json
@@ -34,7 +34,9 @@
     "error": {
       "invalid_ip": "請輸入有效的 IPv4 或 IPv6 位址。",
       "invalid_network": "請輸入有效的 IPv4 網段，例如 192.168.1.0/24。",
-      "scan_failed": "區域網路掃描無法完成。"
+      "scan_failed": "區域網路掃描無法完成。",
+      "cannot_connect": "無法連線到設備。",
+      "unknown": "發生未知錯誤。"
     },
     "abort": {
       "already_configured": "這台大金冷氣已經設定過了。",

--- a/custom_components/local_daikin/translations/zh-Hant.json
+++ b/custom_components/local_daikin/translations/zh-Hant.json
@@ -1,5 +1,15 @@
 {
   "config": {
+    "menu": {
+      "user": {
+        "title": "設定 Local Daikin",
+        "description": "選擇新增大金冷氣的方式。",
+        "menu_options": {
+          "manual": "手動輸入 IP 位址",
+          "scan": "掃描區域網路"
+        }
+      }
+    },
     "step": {
       "user": {
         "title": "新增大金冷氣",
@@ -14,14 +24,25 @@
         "data": {
           "ip_address": "IP 位址"
         }
+      },
+      "scan": {
+        "title": "掃描區域網路",
+        "description": "掃描指定的 IPv4 網段，找出並新增尚未設定的大金 LAN 轉接器。",
+        "data": {
+          "network": "IPv4 網段"
+        }
       }
     },
     "error": {
-      "invalid_ip": "請輸入有效的 IPv4 或 IPv6 位址。"
+      "invalid_ip": "請輸入有效的 IPv4 或 IPv6 位址。",
+      "invalid_network": "請輸入有效的 IPv4 網段，例如 192.168.1.0/24。",
+      "scan_failed": "區域網路掃描無法完成。"
     },
     "abort": {
       "already_configured": "這台大金冷氣已經設定過了。",
-      "reconfigure_successful": "大金冷氣設定已更新。"
+      "reconfigure_successful": "大金冷氣設定已更新。",
+      "no_new_devices": "找不到新的大金冷氣。",
+      "scan_complete": "已新增掃描到的大金冷氣。"
     }
   }
 }

--- a/custom_components/local_daikin/translations/zh-Hant.json
+++ b/custom_components/local_daikin/translations/zh-Hant.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "menu": {
+    "step": {
       "user": {
         "title": "設定 Local Daikin",
         "description": "選擇新增大金冷氣的方式。",
@@ -8,10 +8,8 @@
           "manual": "手動輸入 IP 位址",
           "scan": "掃描區域網路"
         }
-      }
-    },
-    "step": {
-      "user": {
+      },
+      "manual": {
         "title": "新增大金冷氣",
         "description": "輸入大金 LAN 轉接器的 IP 位址。",
         "data": {

--- a/custom_components/local_daikin/translations/zh-Hant.json
+++ b/custom_components/local_daikin/translations/zh-Hant.json
@@ -32,18 +32,21 @@
       }
     },
     "error": {
-      "invalid_ip": "請輸入有效的 IPv4 或 IPv6 位址。",
+      "invalid_ip": "請輸入有效的 IPv4 位址。",
       "invalid_network": "請輸入有效的 IPv4 網段，例如 192.168.1.0/24。",
       "scan_failed": "區域網路掃描無法完成。",
+      "scan_add_failed": "無法新增任何大金冷氣。失敗位址：{failed_ips}。",
       "cannot_connect": "無法連線到設備。",
       "unknown": "發生未知錯誤。"
     },
     "abort": {
       "already_configured": "這台大金冷氣已經設定過了。",
+      "wrong_device": "新位址屬於另一台大金冷氣。",
       "reconfigure_successful": "大金冷氣設定已更新。",
       "no_devices_found": "指定網段找不到大金冷氣。",
       "all_configured": "掃描到的大金冷氣都已經設定過了。",
-      "scan_complete": "已新增掃描到的大金冷氣。"
+      "scan_complete": "已新增 {added} 台大金冷氣；另有 {skipped} 台已設定。",
+      "scan_partial": "已新增 {added} 台、略過 {skipped} 台，另有 {failed} 台新增失敗：{failed_ips}。"
     }
   }
 }

--- a/custom_components/local_daikin/translations/zh-Hant.json
+++ b/custom_components/local_daikin/translations/zh-Hant.json
@@ -39,7 +39,8 @@
     "abort": {
       "already_configured": "這台大金冷氣已經設定過了。",
       "reconfigure_successful": "大金冷氣設定已更新。",
-      "no_new_devices": "找不到新的大金冷氣。",
+      "no_devices_found": "指定網段找不到大金冷氣。",
+      "all_configured": "掃描到的大金冷氣都已經設定過了。",
       "scan_complete": "已新增掃描到的大金冷氣。"
     }
   }

--- a/custom_components/local_daikin/translations/zh-Hant.json
+++ b/custom_components/local_daikin/translations/zh-Hant.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "新增大金冷氣",
+        "description": "輸入大金 LAN 轉接器的 IP 位址。",
+        "data": {
+          "ip_address": "IP 位址"
+        }
+      },
+      "reconfigure": {
+        "title": "重新設定大金冷氣",
+        "description": "更新大金 LAN 轉接器的 IP 位址。",
+        "data": {
+          "ip_address": "IP 位址"
+        }
+      }
+    },
+    "error": {
+      "invalid_ip": "請輸入有效的 IPv4 或 IPv6 位址。"
+    },
+    "abort": {
+      "already_configured": "這台大金冷氣已經設定過了。",
+      "reconfigure_successful": "大金冷氣設定已更新。"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["."]
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py314"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest-homeassistant-custom-component==0.13.346
+ruff==0.15.21

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for Local Daikin tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations) -> None:
+    """Enable loading Local Daikin from custom_components."""
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Prevent entity platforms from starting during config flow tests."""
+    with patch(
+        "custom_components.local_daikin.async_setup_entry",
+        new=AsyncMock(return_value=True),
+    ) as setup_entry:
+        yield setup_entry

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,504 @@
+"""Tests for the Local Daikin configuration flows."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.config_entries import (
+    SOURCE_INTEGRATION_DISCOVERY,
+    SOURCE_RECONFIGURE,
+    SOURCE_USER,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.local_daikin.config_flow import AddEntriesResult
+from custom_components.local_daikin.const import CONF_IP_ADDRESS, DOMAIN
+from custom_components.local_daikin.scanner import (
+    DaikinConnectionError,
+    DaikinDeviceInfo,
+)
+
+OLD_IP = "192.168.31.71"
+NEW_IP = "192.168.31.72"
+MAC = "aa:bb:cc:dd:ee:ff"
+OTHER_MAC = "11:22:33:44:55:66"
+
+
+async def open_step(hass: HomeAssistant, step_id: str) -> dict:
+    """Start the user flow and choose one menu option."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+    return await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": step_id}
+    )
+
+
+async def test_manual_setup_validates_device_and_uses_mac(
+    hass: HomeAssistant,
+) -> None:
+    """Manual setup verifies DSIOT before creating a stable config entry."""
+    result = await open_step(hass, "manual")
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=AsyncMock(return_value=DaikinDeviceInfo(OLD_IP, MAC)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: OLD_IP}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_IP_ADDRESS: OLD_IP}
+    assert result["result"].unique_id == MAC
+
+
+async def test_manual_setup_rejects_ipv6_without_connecting(
+    hass: HomeAssistant,
+) -> None:
+    """The form no longer advertises or accepts unsupported IPv6 addresses."""
+    result = await open_step(hass, "manual")
+    get_device = AsyncMock()
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=get_device,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: "2001:db8::1"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_IP_ADDRESS: "invalid_ip"}
+    get_device.assert_not_awaited()
+
+
+async def test_manual_setup_reports_connection_failure(
+    hass: HomeAssistant,
+) -> None:
+    """A syntactically valid but unreachable address is not saved."""
+    result = await open_step(hass, "manual")
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=AsyncMock(side_effect=DaikinConnectionError),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: OLD_IP}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert hass.config_entries.async_entries(DOMAIN) == []
+
+
+async def test_manual_setup_rejects_duplicate_mac(hass: HomeAssistant) -> None:
+    """A device cannot be added twice after its IP address changes."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    ).add_to_hass(hass)
+    result = await open_step(hass, "manual")
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=AsyncMock(return_value=DaikinDeviceInfo(NEW_IP, MAC)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: NEW_IP}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_manual_setup_rejects_duplicate_ip_before_connecting(
+    hass: HomeAssistant,
+) -> None:
+    """An existing address is rejected without another network request."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    ).add_to_hass(hass)
+    result = await open_step(hass, "manual")
+    get_device = AsyncMock()
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=get_device,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: OLD_IP}
+        )
+
+    assert result["reason"] == "already_configured"
+    get_device.assert_not_awaited()
+
+
+async def test_manual_setup_reports_unexpected_validation_error(
+    hass: HomeAssistant,
+) -> None:
+    """Unexpected validation failures remain recoverable in the form."""
+    result = await open_step(hass, "manual")
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=AsyncMock(side_effect=RuntimeError("unexpected")),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: OLD_IP}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def start_reconfigure(hass: HomeAssistant, entry: MockConfigEntry) -> dict:
+    """Start reconfiguration for an existing entry."""
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+
+async def test_reconfigure_verifies_same_device(hass: HomeAssistant) -> None:
+    """A stable entry accepts a new address only for the same adapter MAC."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    )
+    entry.add_to_hass(hass)
+    result = await start_reconfigure(hass, entry)
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=AsyncMock(return_value=DaikinDeviceInfo(NEW_IP, MAC)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: NEW_IP}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_IP_ADDRESS] == NEW_IP
+    assert entry.unique_id == MAC
+
+
+async def test_reconfigure_rejects_different_device(hass: HomeAssistant) -> None:
+    """Changing an address cannot silently replace the physical device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    )
+    entry.add_to_hass(hass)
+    result = await start_reconfigure(hass, entry)
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=AsyncMock(return_value=DaikinDeviceInfo(NEW_IP, OTHER_MAC)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: NEW_IP}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    assert entry.data[CONF_IP_ADDRESS] == OLD_IP
+    assert entry.unique_id == MAC
+
+
+async def test_reconfigure_migrates_legacy_ip_identity(
+    hass: HomeAssistant,
+) -> None:
+    """A legacy entry moves to the adapter MAC during reconfiguration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=OLD_IP,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    )
+    entry.add_to_hass(hass)
+    result = await start_reconfigure(hass, entry)
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_get_device_info",
+        new=AsyncMock(return_value=DaikinDeviceInfo(NEW_IP, MAC)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_IP_ADDRESS: NEW_IP}
+        )
+
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.unique_id == MAC
+    assert entry.data[CONF_IP_ADDRESS] == NEW_IP
+
+
+async def test_reconfigure_rejects_another_entry_ip(hass: HomeAssistant) -> None:
+    """Reconfiguration cannot steal the address of another entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    )
+    entry.add_to_hass(hass)
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=OTHER_MAC,
+        data={CONF_IP_ADDRESS: NEW_IP},
+    ).add_to_hass(hass)
+    result = await start_reconfigure(hass, entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_IP_ADDRESS: NEW_IP}
+    )
+
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_IP_ADDRESS] == OLD_IP
+
+
+async def test_reconfigure_rejects_ipv6(hass: HomeAssistant) -> None:
+    """Reconfiguration preserves the current entry for unsupported IPv6."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    )
+    entry.add_to_hass(hass)
+    result = await start_reconfigure(hass, entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_IP_ADDRESS: "2001:db8::1"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_IP_ADDRESS: "invalid_ip"}
+    assert entry.data[CONF_IP_ADDRESS] == OLD_IP
+
+
+async def test_scan_reports_partial_addition(hass: HomeAssistant) -> None:
+    """A partially successful scan identifies failed addresses."""
+    devices = [
+        DaikinDeviceInfo(OLD_IP, MAC),
+        DaikinDeviceInfo(NEW_IP, OTHER_MAC),
+    ]
+    result = await open_step(hass, "scan")
+
+    with (
+        patch(
+            "custom_components.local_daikin.config_flow.async_scan_network",
+            new=AsyncMock(return_value=devices),
+        ),
+        patch(
+            "custom_components.local_daikin.config_flow.DaikinConfigFlow._async_add_entries",
+            new=AsyncMock(
+                return_value=AddEntriesResult(
+                    added=(OLD_IP,), skipped=(), failed=(NEW_IP,)
+                )
+            ),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"network": "192.168.31.0/24"}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "scan_partial"
+    assert result["description_placeholders"] == {
+        "added": "1",
+        "skipped": "0",
+        "failed": "1",
+        "failed_ips": NEW_IP,
+    }
+
+
+async def test_scan_adds_all_verified_devices(hass: HomeAssistant) -> None:
+    """Verified scan results create one stable config entry per adapter."""
+    devices = [
+        DaikinDeviceInfo(OLD_IP, MAC),
+        DaikinDeviceInfo(NEW_IP, OTHER_MAC),
+    ]
+    result = await open_step(hass, "scan")
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_scan_network",
+        new=AsyncMock(return_value=devices),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"network": "192.168.31.0/24"}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "scan_complete"
+    assert result["description_placeholders"]["added"] == "2"
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert {entry.unique_id for entry in entries} == {MAC, OTHER_MAC}
+    assert {entry.data[CONF_IP_ADDRESS] for entry in entries} == {OLD_IP, NEW_IP}
+
+
+async def test_scan_filters_devices_already_configured(
+    hass: HomeAssistant,
+) -> None:
+    """A verified device already present by IP and MAC is not added again."""
+    device = DaikinDeviceInfo(OLD_IP, MAC)
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    ).add_to_hass(hass)
+    result = await open_step(hass, "scan")
+
+    with patch(
+        "custom_components.local_daikin.config_flow.async_scan_network",
+        new=AsyncMock(return_value=[device]),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"network": "192.168.31.0/24"}
+        )
+
+    assert result["reason"] == "all_configured"
+
+
+async def test_internal_discovery_rejects_duplicate_ip(
+    hass: HomeAssistant,
+) -> None:
+    """The internal scan source applies the same duplicate-address guard."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_IP_ADDRESS: OLD_IP},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data={CONF_IP_ADDRESS: OLD_IP, "mac": OTHER_MAC},
+    )
+
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("network", "error"),
+    [("not-a-network", "invalid_network"), ("10.0.0.0/21", "invalid_network")],
+)
+async def test_scan_rejects_invalid_network(
+    hass: HomeAssistant, network: str, error: str
+) -> None:
+    """Invalid or excessive scan ranges remain editable in the form."""
+    result = await open_step(hass, "scan")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"network": network}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"network": error}
+
+
+async def test_scan_reports_no_devices(hass: HomeAssistant) -> None:
+    """An empty network scan has a distinct user-facing result."""
+    result = await open_step(hass, "scan")
+    with patch(
+        "custom_components.local_daikin.config_flow.async_scan_network",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"network": "192.168.31.0/24"}
+        )
+
+    assert result["reason"] == "no_devices_found"
+
+
+async def test_scan_reports_scanner_exception(hass: HomeAssistant) -> None:
+    """An unexpected scanner exception returns to a recoverable form."""
+    result = await open_step(hass, "scan")
+    with patch(
+        "custom_components.local_daikin.config_flow.async_scan_network",
+        new=AsyncMock(side_effect=RuntimeError("scan failed")),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"network": "192.168.31.0/24"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "scan_failed"}
+
+
+@pytest.mark.parametrize(
+    ("nested_result", "expected_reason", "expected_error"),
+    [
+        (
+            {"type": FlowResultType.ABORT, "reason": "already_configured"},
+            "all_configured",
+            None,
+        ),
+        (
+            {"type": FlowResultType.FORM, "flow_id": "unfinished"},
+            None,
+            "scan_add_failed",
+        ),
+    ],
+)
+async def test_scan_handles_nested_flow_outcomes(
+    hass: HomeAssistant,
+    nested_result: dict,
+    expected_reason: str | None,
+    expected_error: str | None,
+) -> None:
+    """Per-device flow results are preserved as skipped or failed."""
+    result = await open_step(hass, "scan")
+    device = DaikinDeviceInfo(OLD_IP, MAC)
+
+    with (
+        patch(
+            "custom_components.local_daikin.config_flow.async_scan_network",
+            new=AsyncMock(return_value=[device]),
+        ),
+        patch.object(
+            hass.config_entries.flow,
+            "async_init",
+            new=AsyncMock(return_value=nested_result),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"network": "192.168.31.0/24"}
+        )
+
+    if expected_reason is not None:
+        assert result["reason"] == expected_reason
+    else:
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": expected_error}
+        assert result["description_placeholders"]["failed_ips"] == OLD_IP
+
+
+async def test_scan_handles_nested_flow_exception(hass: HomeAssistant) -> None:
+    """One failed discovery flow returns a recoverable scan error."""
+    result = await open_step(hass, "scan")
+    device = DaikinDeviceInfo(OLD_IP, MAC)
+
+    with (
+        patch(
+            "custom_components.local_daikin.config_flow.async_scan_network",
+            new=AsyncMock(return_value=[device]),
+        ),
+        patch.object(
+            hass.config_entries.flow,
+            "async_init",
+            new=AsyncMock(side_effect=RuntimeError("flow failed")),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"network": "192.168.31.0/24"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "scan_add_failed"}
+    assert result["description_placeholders"]["failed_ips"] == OLD_IP

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,52 @@
+"""Tests for Local Daikin config entry identity migration."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.local_daikin import _async_migrate_legacy_unique_id
+from custom_components.local_daikin.const import CONF_IP_ADDRESS, DOMAIN
+from custom_components.local_daikin.scanner import (
+    DaikinConnectionError,
+    DaikinDeviceInfo,
+)
+
+IP = "192.168.31.71"
+MAC = "aa:bb:cc:dd:ee:ff"
+
+
+async def test_online_legacy_entry_migrates_to_mac(hass: HomeAssistant) -> None:
+    """Reachable legacy entries receive the stable adapter identity."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=IP,
+        data={CONF_IP_ADDRESS: IP},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.local_daikin.async_get_device_info",
+        new=AsyncMock(return_value=DaikinDeviceInfo(IP, MAC)),
+    ):
+        await _async_migrate_legacy_unique_id(hass, entry)
+
+    assert entry.unique_id == MAC
+
+
+async def test_offline_legacy_entry_defers_migration(hass: HomeAssistant) -> None:
+    """A temporary outage never blocks the existing entry from loading."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=IP,
+        data={CONF_IP_ADDRESS: IP},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.local_daikin.async_get_device_info",
+        new=AsyncMock(side_effect=DaikinConnectionError),
+    ):
+        await _async_migrate_legacy_unique_id(hass, entry)
+
+    assert entry.unique_id == IP

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -32,17 +32,15 @@ MAC = "aa:bb:cc:dd:ee:ff"
 
 
 def daikin_response(raw_mac: str = "AABBCCDDEEFF") -> dict:
-    """Build the adapter identity response used by Daikin devices."""
+    """Build the adapter identity response returned by real Daikin devices."""
     return {
         "responses": [
             {
                 "fr": "/dsiot/edge.adp_i",
-                "pc": [
-                    {
-                        "pn": "adp_i",
-                        "pch": [{"pn": "mac", "pv": raw_mac}],
-                    }
-                ],
+                "pc": {
+                    "pn": "adp_i",
+                    "pch": [{"pn": "mac", "pv": raw_mac}],
+                },
             }
         ]
     }
@@ -109,6 +107,18 @@ def test_find_pn_value_handles_malformed_trees() -> None:
     assert _find_pn_value([{}]) is None
     assert _find_pn_value([{"pn": "other"}], "adp_i") is None
     assert _find_pn_value([{"pn": "adp_i", "pch": {}}], "adp_i", "mac") is None
+
+
+def test_find_pn_value_accepts_list_wrapped_root() -> None:
+    """Older fixtures with a list-wrapped root remain supported."""
+    nodes = [
+        {
+            "pn": "adp_i",
+            "pch": [{"pn": "mac", "pv": "AABBCCDDEEFF"}],
+        }
+    ]
+
+    assert _find_pn_value(nodes, "adp_i", "mac") == "AABBCCDDEEFF"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -119,85 +119,84 @@ def test_legacy_unique_id_detection(
 
 
 class FakeResponse:
-    """Minimal aiohttp response context manager for request tests."""
+    """Minimal requests response for transport tests."""
 
     def __init__(self, status: int, data: object) -> None:
-        self.status = status
+        self.status_code = status
         self._data = data
 
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, traceback) -> None:
-        return None
-
-    async def json(self, content_type=None) -> object:
+    def json(self) -> object:
         return self._data
 
 
-class FakeSession:
-    """Minimal aiohttp session for request tests."""
+class FakeHass:
+    """Run executor jobs immediately while preserving the async API."""
 
-    def __init__(self, response: FakeResponse) -> None:
-        self.response = response
-
-    def post(self, *args, **kwargs) -> FakeResponse:
-        return self.response
+    async def async_add_executor_job(self, target, *args):
+        return target(*args)
 
 
 async def test_fetch_device_info_validates_http_response() -> None:
     """The probe returns identity only after a successful DSIOT response."""
-    device = await _async_fetch_device_info(
-        FakeSession(FakeResponse(200, daikin_response())), "192.168.31.71"
-    )
+    hass = FakeHass()
+    with patch(
+        "custom_components.local_daikin.scanner.requests.post",
+        return_value=FakeResponse(200, daikin_response()),
+    ):
+        device = await _async_fetch_device_info(hass, "192.168.31.71")
     assert device.mac == format_mac("AABBCCDDEEFF")
 
-    with pytest.raises(DaikinConnectionError):
-        await _async_fetch_device_info(
-            FakeSession(FakeResponse(404, {})), "192.168.31.72"
-        )
+    with (
+        patch(
+            "custom_components.local_daikin.scanner.requests.post",
+            return_value=FakeResponse(404, {}),
+        ),
+        pytest.raises(DaikinConnectionError),
+    ):
+        await _async_fetch_device_info(hass, "192.168.31.72")
 
 
 def test_discovery_timeout_allows_slow_lan_adapters() -> None:
     """Discovery tolerates adapters delayed by ARP and Wi-Fi wake-up."""
     assert SCAN_CONCURRENCY == 8
-    assert REQUEST_TIMEOUT.total == 4.0
-    assert REQUEST_TIMEOUT.connect == 2.0
-    assert REQUEST_TIMEOUT.sock_read == 2.0
+    assert REQUEST_TIMEOUT == (2.0, 2.0)
 
 
 async def test_fetch_device_info_maps_network_errors() -> None:
     """Expected transport failures become a config-flow connection error."""
-
-    class BrokenSession:
-        def post(self, *args, **kwargs):
-            raise OSError("offline")
-
-    with pytest.raises(DaikinConnectionError):
-        await _async_fetch_device_info(BrokenSession(), "192.168.31.71")
+    with (
+        patch(
+            "custom_components.local_daikin.scanner.requests.post",
+            side_effect=OSError("offline"),
+        ),
+        pytest.raises(DaikinConnectionError),
+    ):
+        await _async_fetch_device_info(FakeHass(), "192.168.31.71")
 
 
 async def test_public_probe_helpers_share_validation() -> None:
     """Manual validation and scan probes use the same response parser."""
-    session = FakeSession(FakeResponse(200, daikin_response()))
+    hass = FakeHass()
     with patch(
-        "custom_components.local_daikin.scanner.async_get_clientsession",
-        return_value=session,
+        "custom_components.local_daikin.scanner.requests.post",
+        return_value=FakeResponse(200, daikin_response()),
     ):
-        device = await async_get_device_info(object(), "192.168.31.71")
+        device = await async_get_device_info(hass, "192.168.31.71")
+        assert await _probe_ip(
+            hass, "192.168.31.71", asyncio.Semaphore(1)
+        ) == device
     assert device.mac == format_mac("AABBCCDDEEFF")
 
-    assert await _probe_ip(
-        session, "192.168.31.71", asyncio.Semaphore(1)
-    ) == device
-    assert (
-        await _probe_ip(
-            FakeSession(FakeResponse(404, {})),
-            "192.168.31.72",
-            asyncio.Semaphore(1),
+    with patch(
+        "custom_components.local_daikin.scanner.requests.post",
+        return_value=FakeResponse(404, {}),
+    ):
+        assert (
+            await _probe_ip(
+                hass, "192.168.31.72", asyncio.Semaphore(1)
+            )
+            is None
         )
-        is None
-    )
 
 
 async def test_scan_returns_devices_in_numeric_ip_order() -> None:
@@ -209,18 +208,12 @@ async def test_scan_returns_devices_in_numeric_ip_order() -> None:
         ),
     }
 
-    async def probe(_session, ip: str, _semaphore):
+    async def probe(_hass, ip: str, _semaphore):
         return devices.get(ip)
 
-    with (
-        patch(
-            "custom_components.local_daikin.scanner.async_get_clientsession",
-            return_value=object(),
-        ),
-        patch(
-            "custom_components.local_daikin.scanner._probe_ip",
-            new=AsyncMock(side_effect=probe),
-        ),
+    with patch(
+        "custom_components.local_daikin.scanner._probe_ip",
+        new=AsyncMock(side_effect=probe),
     ):
         result = await async_scan_network(
             object(), ipaddress.ip_network("192.168.31.0/30")

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -9,11 +9,13 @@ import pytest
 from homeassistant.helpers.device_registry import format_mac
 
 from custom_components.local_daikin.scanner import (
-    REQUEST_TIMEOUT,
+    CONNECT_TIMEOUT,
+    READ_TIMEOUT,
     SCAN_CONCURRENCY,
     DaikinConnectionError,
     DaikinDeviceInfo,
     _async_fetch_device_info,
+    _async_request_device_info,
     _find_pn_value,
     _parse_device_info,
     _probe_ip,
@@ -118,68 +120,99 @@ def test_legacy_unique_id_detection(
     assert uses_legacy_unique_id(unique_id) is expected
 
 
-class FakeResponse:
-    """Minimal requests response for transport tests."""
+class FakeReader:
+    """Minimal stream reader for Daikin HTTP transport tests."""
 
     def __init__(self, status: int, data: object) -> None:
-        self.status_code = status
-        self._data = data
+        import json
 
-    def json(self) -> object:
-        return self._data
+        self.body = json.dumps(data).encode()
+        self.headers = (
+            f"HTTP/1.1 {status} Test\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {len(self.body)}\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode()
+
+    async def readuntil(self, separator: bytes) -> bytes:
+        assert separator == b"\r\n\r\n"
+        return self.headers
+
+    async def readexactly(self, size: int) -> bytes:
+        assert size == len(self.body)
+        return self.body
 
 
-class FakeHass:
-    """Run executor jobs immediately while preserving the async API."""
+class FakeWriter:
+    """Minimal stream writer that captures the outgoing HTTP request."""
 
-    async def async_add_executor_job(self, target, *args):
-        return target(*args)
+    def __init__(self) -> None:
+        self.request = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.request += data
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
 
 
 async def test_fetch_device_info_validates_http_response() -> None:
     """The probe returns identity only after a successful DSIOT response."""
-    hass = FakeHass()
+    writer = FakeWriter()
     with patch(
-        "custom_components.local_daikin.scanner.requests.post",
-        return_value=FakeResponse(200, daikin_response()),
+        "custom_components.local_daikin.scanner.asyncio.open_connection",
+        new=AsyncMock(return_value=(FakeReader(200, daikin_response()), writer)),
     ):
-        device = await _async_fetch_device_info(hass, "192.168.31.71")
+        device = await _async_fetch_device_info(object(), "192.168.31.71")
     assert device.mac == format_mac("AABBCCDDEEFF")
+    assert b"POST /dsiot/multireq HTTP/1.1" in writer.request
+    assert b"Connection: close" in writer.request
+    assert writer.closed
 
     with (
         patch(
-            "custom_components.local_daikin.scanner.requests.post",
-            return_value=FakeResponse(404, {}),
+            "custom_components.local_daikin.scanner.asyncio.open_connection",
+            new=AsyncMock(return_value=(FakeReader(404, {}), FakeWriter())),
         ),
         pytest.raises(DaikinConnectionError),
     ):
-        await _async_fetch_device_info(hass, "192.168.31.72")
+        await _async_request_device_info("192.168.31.72")
 
 
 def test_discovery_timeout_allows_slow_lan_adapters() -> None:
     """Discovery tolerates adapters delayed by ARP and Wi-Fi wake-up."""
     assert SCAN_CONCURRENCY == 8
-    assert REQUEST_TIMEOUT == (2.0, 2.0)
+    assert CONNECT_TIMEOUT == 2.0
+    assert READ_TIMEOUT == 2.0
 
 
 async def test_fetch_device_info_maps_network_errors() -> None:
     """Expected transport failures become a config-flow connection error."""
     with (
         patch(
-            "custom_components.local_daikin.scanner.requests.post",
+            "custom_components.local_daikin.scanner.asyncio.open_connection",
+            new=AsyncMock(
             side_effect=OSError("offline"),
+            ),
         ),
         pytest.raises(DaikinConnectionError),
     ):
-        await _async_fetch_device_info(FakeHass(), "192.168.31.71")
+        await _async_request_device_info("192.168.31.71")
 
 
 async def test_public_probe_helpers_share_validation() -> None:
     """Manual validation and scan probes use the same response parser."""
-    hass = FakeHass()
+    hass = object()
     with patch(
-        "custom_components.local_daikin.scanner.requests.post",
-        return_value=FakeResponse(200, daikin_response()),
+        "custom_components.local_daikin.scanner._async_request_device_info",
+        new=AsyncMock(return_value=daikin_response()),
     ):
         device = await async_get_device_info(hass, "192.168.31.71")
         assert await _probe_ip(
@@ -188,8 +221,8 @@ async def test_public_probe_helpers_share_validation() -> None:
     assert device.mac == format_mac("AABBCCDDEEFF")
 
     with patch(
-        "custom_components.local_daikin.scanner.requests.post",
-        return_value=FakeResponse(404, {}),
+        "custom_components.local_daikin.scanner._async_request_device_info",
+        new=AsyncMock(side_effect=DaikinConnectionError("offline")),
     ):
         assert (
             await _probe_ip(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.helpers.device_registry import format_mac
 
 from custom_components.local_daikin.scanner import (
+    CLOSE_TIMEOUT,
     CONNECT_TIMEOUT,
     READ_TIMEOUT,
     SCAN_CONCURRENCY,
@@ -191,6 +192,7 @@ def test_discovery_timeout_allows_slow_lan_adapters() -> None:
     assert SCAN_CONCURRENCY == 8
     assert CONNECT_TIMEOUT == 2.0
     assert READ_TIMEOUT == 2.0
+    assert CLOSE_TIMEOUT == 0.5
 
 
 async def test_fetch_device_info_maps_network_errors() -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.device_registry import format_mac
 
 from custom_components.local_daikin.scanner import (
     REQUEST_TIMEOUT,
+    SCAN_CONCURRENCY,
     DaikinConnectionError,
     DaikinDeviceInfo,
     _async_fetch_device_info,
@@ -159,6 +160,7 @@ async def test_fetch_device_info_validates_http_response() -> None:
 
 def test_discovery_timeout_allows_slow_lan_adapters() -> None:
     """Discovery tolerates adapters delayed by ARP and Wi-Fi wake-up."""
+    assert SCAN_CONCURRENCY == 8
     assert REQUEST_TIMEOUT.total == 4.0
     assert REQUEST_TIMEOUT.connect == 2.0
     assert REQUEST_TIMEOUT.sock_read == 2.0

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import format_mac
 from custom_components.local_daikin.scanner import (
     CLOSE_TIMEOUT,
     CONNECT_TIMEOUT,
+    PROBE_TIMEOUT,
     READ_TIMEOUT,
     SCAN_CONCURRENCY,
     DaikinConnectionError,
@@ -193,6 +194,7 @@ def test_discovery_timeout_allows_slow_lan_adapters() -> None:
     assert CONNECT_TIMEOUT == 2.0
     assert READ_TIMEOUT == 2.0
     assert CLOSE_TIMEOUT == 0.5
+    assert PROBE_TIMEOUT == 6.0
 
 
 async def test_fetch_device_info_maps_network_errors() -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.helpers.device_registry import format_mac
 
 from custom_components.local_daikin.scanner import (
+    REQUEST_TIMEOUT,
     DaikinConnectionError,
     DaikinDeviceInfo,
     _async_fetch_device_info,
@@ -154,6 +155,13 @@ async def test_fetch_device_info_validates_http_response() -> None:
         await _async_fetch_device_info(
             FakeSession(FakeResponse(404, {})), "192.168.31.72"
         )
+
+
+def test_discovery_timeout_allows_slow_lan_adapters() -> None:
+    """Discovery tolerates adapters delayed by ARP and Wi-Fi wake-up."""
+    assert REQUEST_TIMEOUT.total == 4.0
+    assert REQUEST_TIMEOUT.connect == 2.0
+    assert REQUEST_TIMEOUT.sock_read == 2.0
 
 
 async def test_fetch_device_info_maps_network_errors() -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,219 @@
+"""Tests for Local Daikin network discovery."""
+
+import asyncio
+import ipaddress
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.helpers.device_registry import format_mac
+
+from custom_components.local_daikin.scanner import (
+    DaikinConnectionError,
+    DaikinDeviceInfo,
+    _async_fetch_device_info,
+    _find_pn_value,
+    _parse_device_info,
+    _probe_ip,
+    async_get_device_info,
+    async_scan_network,
+    get_default_network,
+    parse_network,
+    uses_legacy_unique_id,
+)
+
+MAC = "aa:bb:cc:dd:ee:ff"
+
+
+def daikin_response(raw_mac: str = "AABBCCDDEEFF") -> dict:
+    """Build the adapter identity response used by Daikin devices."""
+    return {
+        "responses": [
+            {
+                "fr": "/dsiot/edge.adp_i",
+                "pc": [
+                    {
+                        "pn": "adp_i",
+                        "pch": [{"pn": "mac", "pv": raw_mac}],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_parse_device_info_uses_mac_as_identity() -> None:
+    """A supported response produces a normalized stable identity."""
+    device = _parse_device_info("192.168.31.71", daikin_response())
+
+    assert device == DaikinDeviceInfo(
+        ip="192.168.31.71", mac=format_mac("AABBCCDDEEFF")
+    )
+
+
+@pytest.mark.parametrize(
+    "data", [None, {}, {"responses": []}, {"responses": [{}]}]
+)
+def test_parse_device_info_rejects_non_daikin_responses(data: object) -> None:
+    """An address without a valid adapter identity is rejected."""
+    with pytest.raises(DaikinConnectionError):
+        _parse_device_info("192.168.31.71", data)
+
+
+@pytest.mark.parametrize("raw_mac", ["", "not-a-mac", "GGGGGGGGGGGG"])
+def test_parse_device_info_rejects_invalid_mac(raw_mac: str) -> None:
+    """The adapter marker alone is insufficient without a valid MAC."""
+    with pytest.raises(DaikinConnectionError):
+        _parse_device_info("192.168.31.71", daikin_response(raw_mac))
+
+
+def test_parse_network_accepts_only_bounded_ipv4_networks() -> None:
+    """Network scans stay within the IPv4 size supported by the UI."""
+    assert str(parse_network("192.168.31.71/24")) == "192.168.31.0/24"
+
+    with pytest.raises(ValueError):
+        parse_network("2001:db8::/64")
+    with pytest.raises(ValueError):
+        parse_network("10.0.0.0/21")
+
+
+@pytest.mark.parametrize(
+    ("local_ip", "expected"),
+    [
+        ("192.168.31.79", "192.168.31.0/24"),
+        (None, None),
+        ("not-an-ip", None),
+        ("2001:db8::1", None),
+    ],
+)
+def test_default_network_uses_home_assistant_ipv4(
+    local_ip: str | None, expected: str | None
+) -> None:
+    """The suggested scan range is derived only from a valid local IPv4."""
+    hass = SimpleNamespace(
+        config=SimpleNamespace(api=SimpleNamespace(local_ip=local_ip))
+    )
+    assert get_default_network(hass) == expected
+
+
+def test_find_pn_value_handles_malformed_trees() -> None:
+    """Malformed adapter payloads fail closed without parser exceptions."""
+    assert _find_pn_value(None, "adp_i") is None
+    assert _find_pn_value([], "adp_i") is None
+    assert _find_pn_value([{}]) is None
+    assert _find_pn_value([{"pn": "other"}], "adp_i") is None
+    assert _find_pn_value([{"pn": "adp_i", "pch": {}}], "adp_i", "mac") is None
+
+
+@pytest.mark.parametrize(
+    ("unique_id", "expected"),
+    [(None, True), ("192.168.31.71", True), (MAC, False)],
+)
+def test_legacy_unique_id_detection(
+    unique_id: str | None, expected: bool
+) -> None:
+    """Only missing and IP-based identities are considered legacy."""
+    assert uses_legacy_unique_id(unique_id) is expected
+
+
+class FakeResponse:
+    """Minimal aiohttp response context manager for request tests."""
+
+    def __init__(self, status: int, data: object) -> None:
+        self.status = status
+        self._data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+    async def json(self, content_type=None) -> object:
+        return self._data
+
+
+class FakeSession:
+    """Minimal aiohttp session for request tests."""
+
+    def __init__(self, response: FakeResponse) -> None:
+        self.response = response
+
+    def post(self, *args, **kwargs) -> FakeResponse:
+        return self.response
+
+
+async def test_fetch_device_info_validates_http_response() -> None:
+    """The probe returns identity only after a successful DSIOT response."""
+    device = await _async_fetch_device_info(
+        FakeSession(FakeResponse(200, daikin_response())), "192.168.31.71"
+    )
+    assert device.mac == format_mac("AABBCCDDEEFF")
+
+    with pytest.raises(DaikinConnectionError):
+        await _async_fetch_device_info(
+            FakeSession(FakeResponse(404, {})), "192.168.31.72"
+        )
+
+
+async def test_fetch_device_info_maps_network_errors() -> None:
+    """Expected transport failures become a config-flow connection error."""
+
+    class BrokenSession:
+        def post(self, *args, **kwargs):
+            raise OSError("offline")
+
+    with pytest.raises(DaikinConnectionError):
+        await _async_fetch_device_info(BrokenSession(), "192.168.31.71")
+
+
+async def test_public_probe_helpers_share_validation() -> None:
+    """Manual validation and scan probes use the same response parser."""
+    session = FakeSession(FakeResponse(200, daikin_response()))
+    with patch(
+        "custom_components.local_daikin.scanner.async_get_clientsession",
+        return_value=session,
+    ):
+        device = await async_get_device_info(object(), "192.168.31.71")
+    assert device.mac == format_mac("AABBCCDDEEFF")
+
+    assert await _probe_ip(
+        session, "192.168.31.71", asyncio.Semaphore(1)
+    ) == device
+    assert (
+        await _probe_ip(
+            FakeSession(FakeResponse(404, {})),
+            "192.168.31.72",
+            asyncio.Semaphore(1),
+        )
+        is None
+    )
+
+
+async def test_scan_returns_devices_in_numeric_ip_order() -> None:
+    """Concurrent probes return structured identities in stable address order."""
+    devices = {
+        "192.168.31.1": DaikinDeviceInfo("192.168.31.1", MAC),
+        "192.168.31.2": DaikinDeviceInfo(
+            "192.168.31.2", "aa:bb:cc:dd:ee:02"
+        ),
+    }
+
+    async def probe(_session, ip: str, _semaphore):
+        return devices.get(ip)
+
+    with (
+        patch(
+            "custom_components.local_daikin.scanner.async_get_clientsession",
+            return_value=object(),
+        ),
+        patch(
+            "custom_components.local_daikin.scanner._probe_ip",
+            new=AsyncMock(side_effect=probe),
+        ),
+    ):
+        result = await async_scan_network(
+            object(), ipaddress.ip_network("192.168.31.0/30")
+        )
+
+    assert [device.ip for device in result] == ["192.168.31.1", "192.168.31.2"]


### PR DESCRIPTION
## Summary

- Add a Home Assistant UI configuration and reconfiguration flow for Local Daikin.
- Add English and Traditional Chinese config-flow translations.
- Add bounded IPv4 LAN discovery with stable MAC-based device identity and duplicate protection.
- Parse the response shape returned by real Daikin adapters.

## Root cause fixed

Real adapters return the `pc` field as a nested object, while the previous discovery parser only accepted a list-wrapped root. The parser therefore rejected reachable Daikin adapters as unsupported devices. The updated parser accepts the real response shape and keeps compatibility with list-wrapped data.

## Validation

- Local scanner test suite: 23 passed.
- Ruff and Python compilation checks passed.
- GitHub Actions checks passed.
- Home Assistant 2026.7.1 deployment verified with `ha core check` and restart.
- HA-host network probes found the three configured adapters at `192.168.31.66`, `192.168.31.71`, and `192.168.31.88`.
- Main bedroom device remained available with 12 entities and live sensor values after deployment.
